### PR TITLE
check if favicon exists before querying it

### DIFF
--- a/src/createSiteNode.js
+++ b/src/createSiteNode.js
@@ -21,11 +21,13 @@ module.exports = function(repo, createNode) {
     delete node.favicon;
     delete node.faviconMetaTags;
 
-    node.faviconMetaTags___NODE = createFaviconMetaTagsNode(
-      node,
-      site,
-      createNode
-    );
+    if (site.favicon) {
+      node.faviconMetaTags___NODE = createFaviconMetaTagsNode(
+        node,
+        site,
+        createNode
+      );
+    }
 
     node.locale = locale;
 


### PR DESCRIPTION
Before calling `createFaviconMetaTagsNode` which creates the GraphQL query for the favicon meta tags, let's check if the favicon exists in Dato's site settings. This prevents the plugin from crashing when no favicon is set.