### PR TITLE
Prevent missing entities from causing exceptions during create nodes

### DIFF
--- a/src/hooks/sourceNodes/createNodeFromEntity/item/itemNodeId.js
+++ b/src/hooks/sourceNodes/createNodeFromEntity/item/itemNodeId.js
@@ -6,6 +6,10 @@ module.exports = function itemNodeId(id, locale, entitiesRepo) {
   }
 
   const entity = entitiesRepo.findEntity('item', id);
+  if (!entity) {
+    return null;
+  }
+
   const type = pascalize(entity.itemType.apiKey);
 
   return `DatoCms${type}-${entity.id}-${locale}`;


### PR DESCRIPTION
Every now and then ID's are orphaned within Dato, this causes the entity object here to be requested with an ID that doesn't actually exist anymore.
While this still causes an issue within DatoCMS (failure to load items for editing) it would be preferable to not also have our builds failing.