### PR TITLE
Consider maxHeight in fluidResolver

### DIFF
--- a/src/hooks/setFieldsOnGraphQLNodeType/nodes/upload/fluidResolver.js
+++ b/src/hooks/setFieldsOnGraphQLNodeType/nodes/upload/fluidResolver.js
@@ -61,7 +61,7 @@ module.exports = cacheDir => ({
 
     const aspectRatio = finalWidth / finalHeight;
 
-    const realMaxWidth = maxWidth || maxHeight * aspectRatio;
+    const realMaxWidth = maxHeight ? maxHeight * aspectRatio : maxWidth;
 
     const realSizes =
       sizes || `(max-width: ${realMaxWidth}px) 100vw, ${realMaxWidth}px`;


### PR DESCRIPTION
One way to tackle fluid images and maybe fix #60 is to say:

* if nothing is specified we default to 800px wide
* if maxWidth is specified we use that value instead
* if maxHeight is specified we use that value multiplied by the aspect
ratio
* if both maxWidth an maxHeight are specified we use maxHeight (this is
arbitrary and not sure which one is preferable)

Before this code change maxHeight was always ignored as maxWidth has
800px as a default value and so it's never empty.