### PR TITLE
change to gatsby import

### DIFF
--- a/fragments/asset.js
+++ b/fragments/asset.js
@@ -1,4 +1,4 @@
-const { graphql } = require('gatsby');
+import { graphql } from 'gatsby';
 
 export const datoCmsAssetResolutions = graphql`
   fragment GatsbyDatoCmsResolutions on DatoCmsFixed {

--- a/fragments/favicon.js
+++ b/fragments/favicon.js
@@ -1,4 +1,4 @@
-const { graphql } = require('gatsby');
+import { graphql } from 'gatsby';
 
 export const datoCmsFaviconMetaTags = graphql`
   fragment GatsbyDatoCmsFaviconMetaTags on DatoCmsFaviconMetaTags {

--- a/fragments/seo.js
+++ b/fragments/seo.js
@@ -1,4 +1,4 @@
-const { graphql } = require('gatsby');
+import { graphql } from 'gatsby';
 
 export const datoCmsSeoMetaTags = graphql`
   fragment GatsbyDatoCmsSeoMetaTags on DatoCmsSeoMetaTags {


### PR DESCRIPTION
Code generation tool (graphql-codegen) or its dependency (graphql-tag-pluck) appear to not be able to resolve gatsby’s graphql-tag when using `require`.   Updating these to use `import` syntax resolves this issue.   This is the same format used by gatsby-source-contentful as well.

Without this change we are not able to reference the fragments when generating TS types.
