### PR TITLE
Implement incremental data updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /hooks
 /old
 /node_modules
+/utils.js
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-source-datocms",
-  "version": "2.1.28",
+  "name": "@gatsbyjs/gatsby-source-datocms",
+  "version": "2.2.0",
   "description": "Gatsby source plugin for building websites using DatoCMS as data source",
   "main": "index.js",
   "scripts": {
@@ -47,5 +47,13 @@
     "gatsby": "^2.12.1",
     "react": "*",
     "react-helmet": "*"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/sidharthachatterjee/gatsby-source-datocms.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sidharthachatterjee/gatsby-source-datocms/issues"
+  },
+  "homepage": "https://github.com/sidharthachatterjee/gatsby-source-datocms#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatsbyjs/gatsby-source-datocms",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Gatsby source plugin for building websites using DatoCMS as data source",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatsbyjs/gatsby-source-datocms",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Gatsby source plugin for building websites using DatoCMS as data source",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "core-js": "^3.2.1",
-    "datocms-client": ">=3.0.16",
+    "datocms-client": ">=3.0.18",
     "fs-extra": ">=8.1.0",
     "humps": ">=2.0.1",
     "imgix-url-params": "11.2.0",

--- a/src/hooks/createSchemaCustomization/index.js
+++ b/src/hooks/createSchemaCustomization/index.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 const { SiteClient, Loader } = require('datocms-client');
-const createTypes = require('./createTypes');
+const createTypes = require('../sourceNodes/createTypes');
 
 const CLIENT_HEADERS = {
   'X-Reason': 'dump',

--- a/src/hooks/createSchemaCustomization/index.js
+++ b/src/hooks/createSchemaCustomization/index.js
@@ -1,24 +1,16 @@
 const fs = require('fs-extra');
-const { SiteClient, Loader } = require('datocms-client');
 const finalizeNodesCreation = require('../sourceNodes/finalizeNodesCreation');
 const createTypes = require('../sourceNodes/createTypes');
 
-const CLIENT_HEADERS = {
-  'X-Reason': 'dump',
-  'X-SSG': 'gatsby',
-};
+const { getClient, getLoader } = require('../../utils');
 
 module.exports = async (
   { actions, getNode, getNodesByType, reporter, parentSpan, schema, store },
   { apiToken, previewMode, apiUrl, localeFallbacks: rawLocaleFallbacks },
 ) => {
-  let client = apiUrl
-    ? new SiteClient(apiToken, CLIENT_HEADERS, apiUrl)
-    : new SiteClient(apiToken, CLIENT_HEADERS);
-
   const localeFallbacks = rawLocaleFallbacks || {};
 
-  const loader = new Loader(client, process.env.GATSBY_CLOUD || previewMode);
+  const loader = getLoader({ apiToken, previewMode, apiUrl });
 
   const program = store.getState().program;
   const cacheDir = `${program.directory}/.cache/datocms-assets`;

--- a/src/hooks/createSchemaCustomization/index.js
+++ b/src/hooks/createSchemaCustomization/index.js
@@ -1,5 +1,6 @@
 const fs = require('fs-extra');
 const { SiteClient, Loader } = require('datocms-client');
+const finalizeNodesCreation = require('../sourceNodes/finalizeNodesCreation');
 const createTypes = require('../sourceNodes/createTypes');
 
 const CLIENT_HEADERS = {
@@ -8,7 +9,7 @@ const CLIENT_HEADERS = {
 };
 
 module.exports = async (
-  { actions, getNode, getNodesByType, schema, store },
+  { actions, getNode, getNodesByType, reporter, parentSpan, schema, store },
   { apiToken, previewMode, apiUrl, localeFallbacks: rawLocaleFallbacks },
 ) => {
   let client = apiUrl
@@ -36,6 +37,19 @@ module.exports = async (
     store,
     cacheDir,
   };
+
+  let activity;
+
+  activity = reporter.activityTimer(`loading DatoCMS schema`, {
+    parentSpan,
+  });
+
+  activity.start();
+
+  await loader.loadSchema();
+  finalizeNodesCreation(context);
+
+  activity.end();
 
   createTypes(context);
 };

--- a/src/hooks/sourceNodes/createNodeFromEntity/item/index.js
+++ b/src/hooks/sourceNodes/createNodeFromEntity/item/index.js
@@ -1,5 +1,4 @@
 const { camelize, pascalize } = require('humps');
-const { Site, Item } = require('datocms-client');
 const entries = require('object.entries');
 
 const buildNode = require('../utils/buildNode');
@@ -9,7 +8,7 @@ const addField = require('./addField');
 
 module.exports = function buildItemNode(
   entity,
-  { entitiesRepo, getNode, actions, localeFallbacks },
+  { entitiesRepo, localeFallbacks },
 ) {
   const siteEntity = entitiesRepo.site;
   const type = pascalize(entity.itemType.apiKey);
@@ -54,7 +53,7 @@ module.exports = function buildItemNode(
                   entitiesRepo,
                   innerI18n,
                   additionalNodesToCreate,
-                  `${camelize(field.apiKey)}-${locale}-`
+                  `${camelize(field.apiKey)}-${locale}-`,
                 );
                 return result;
               });

--- a/src/hooks/sourceNodes/index.js
+++ b/src/hooks/sourceNodes/index.js
@@ -1,14 +1,10 @@
 const fs = require('fs-extra');
-const { SiteClient, Loader } = require('datocms-client');
 const createNodeFromEntity = require('./createNodeFromEntity');
 const destroyEntityNode = require('./destroyEntityNode');
 const finalizeNodesCreation = require('./finalizeNodesCreation');
 const Queue = require('promise-queue');
 
-const CLIENT_HEADERS = {
-  'X-Reason': 'dump',
-  'X-SSG': 'gatsby',
-};
+const { getClient, getLoader } = require('../../utils');
 
 module.exports = async (
   { actions, getNode, getNodesByType, reporter, parentSpan, schema, store },
@@ -20,13 +16,9 @@ module.exports = async (
     localeFallbacks: rawLocaleFallbacks,
   },
 ) => {
-  let client = apiUrl
-    ? new SiteClient(apiToken, CLIENT_HEADERS, apiUrl)
-    : new SiteClient(apiToken, CLIENT_HEADERS);
-
   const localeFallbacks = rawLocaleFallbacks || {};
 
-  const loader = new Loader(client, process.env.GATSBY_CLOUD || previewMode);
+  const loader = getLoader({ apiToken, previewMode, apiUrl });
 
   const program = store.getState().program;
   const cacheDir = `${program.directory}/.cache/datocms-assets`;

--- a/src/hooks/sourceNodes/index.js
+++ b/src/hooks/sourceNodes/index.js
@@ -76,7 +76,7 @@ module.exports = async (
         } else if (event_type === 'unpublish') {
           loader.entitiesRepo.destroyEntities('item', [entity_id]);
         } else {
-          console.log(`Invalid event type ${event_type}`);
+          reporter.warn(`Invalid event type ${event_type}`);
         }
         break;
 
@@ -95,11 +95,11 @@ module.exports = async (
         } else if (event_type === 'delete') {
           loader.entitiesRepo.destroyEntities('upload', [entity_id]);
         } else {
-          console.log(`Invalid event type ${event_type}`);
+          reporter.warn(`Invalid event type ${event_type}`);
         }
         break;
       default:
-        console.log(`Invalid entity type ${entity_type}`);
+        reporter.warn(`Invalid entity type ${entity_type}`);
         break;
     }
     changesActivity.end();

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,7 +36,21 @@ function getClient(options) {
   return client;
 }
 
+async function getEntity(items, id, version) {
+  try {
+    const result = await items.find(id, {
+      version,
+    });
+    return result;
+  } catch (err) {
+    console.log('Error loading entity', err);
+    return undefined;
+  }
+}
+
 module.exports = {
   getClient,
   getLoader,
+  getEntity,
 };
+  

--- a/src/utils.js
+++ b/src/utils.js
@@ -36,21 +36,7 @@ function getClient(options) {
   return client;
 }
 
-async function getEntity(items, id, version) {
-  try {
-    const result = await items.find(id, {
-      version,
-    });
-    return result;
-  } catch (err) {
-    console.log('Error loading entity', err);
-    return undefined;
-  }
-}
-
 module.exports = {
   getClient,
   getLoader,
-  getEntity,
 };
-  

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,42 @@
+const { SiteClient, Loader } = require('datocms-client');
+
+const CLIENT_HEADERS = {
+  'X-Reason': 'dump',
+  'X-SSG': 'gatsby',
+};
+
+const GATSBY_CLOUD = process.env.GATSBY_CLOUD;
+
+let client, loader;
+
+function createClient({ apiToken, apiUrl }) {
+  return apiUrl
+    ? new SiteClient(apiToken, CLIENT_HEADERS, apiUrl)
+    : new SiteClient(apiToken, CLIENT_HEADERS);
+}
+
+function createLoader({ apiToken, apiUrl, previewMode }) {
+  if (!client) {
+    client = createClient({ apiToken, apiUrl });
+  }
+  return new Loader(client, GATSBY_CLOUD || previewMode);
+}
+
+function getLoader(options) {
+  if (!loader) {
+    loader = createLoader(options);
+  }
+  return loader;
+}
+
+function getClient(options) {
+  if (!client) {
+    client = createClient(options);
+  }
+  return client;
+}
+
+module.exports = {
+  getClient,
+  getLoader,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,6 +981,11 @@ boolbase@~1.0.0:
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
+bottleneck@^2.19.5:
+  version "2.19.5"
+  resolved "https://registry.yarnpkg.com/bottleneck/-/bottleneck-2.19.5.tgz#5df0b90f59fd47656ebe63c78a98419205cadd91"
+  integrity sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==
+
 boxen@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-3.2.0.tgz#fbdff0de93636ab4450886b6ff45b92d098f45eb"
@@ -1511,14 +1516,15 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-datocms-client@>=3.0.16:
-  version "3.0.16"
-  resolved "https://registry.yarnpkg.com/datocms-client/-/datocms-client-3.0.16.tgz#2623dfd46626bacc3f6b3dcfe3d3dde1fcd50acf"
-  integrity sha512-X82PtiD13q5AhKynCBrC4COIM9pSJ5a5Xw5oTzBe4+b8yRboBrJSdndiBf1r8od0wWKw9kZMyMJx2LP6iom3RQ==
+datocms-client@>=3.0.18:
+  version "3.0.18"
+  resolved "https://registry.yarnpkg.com/datocms-client/-/datocms-client-3.0.18.tgz#a9df403516ea98802efae10c580f8808f1ae85f3"
+  integrity sha512-5pSJjsyF7mvtPFQZ3RUFWK4Lz01Kg3Hq1glCKCzsuhfwN/iGnLoe1/nmyInLAQoiEMSl/f2AnOvt3stINrp6fw==
   dependencies:
     "@iarna/toml" "^2.2.3"
     arr-diff "^4.0.0"
     axios "^0.19.0"
+    bottleneck "^2.19.5"
     chokidar "^3.3.0"
     clui "^0.3.6"
     colors "^1.4.0"


### PR DESCRIPTION
The changes in this PR enable this plugin to use Gatsby's refresh endpoint to incrementally _source_ nodes. This requires webhooks from Dato to be set since the plugin now uses the metadata passed in to fetch new data. The required webhook settings are

### Triggers

Entity: Record 
Events: Publish, Unpublish

Entity: Asset 
Events: Create, Update, Delete 

Entity: Model 
Events: Create, Update, Delete 

### HTTP Body

Send a custom payload? :white_check_mark: 
```
{
  "event_type": "{{event_type}}",
  "entity_id": "{{#entity}}{{id}}{{/entity}}",
  "entity_type": "{{entity_type}}"
}
```

(These are now the default in the auto provision for Gatsby Cloud)