### PR TITLE
support react-helmet v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "peerDependencies": {
     "gatsby": "^2.12.1",
     "react": "*",
-    "react-helmet": "*"
+    "react-helmet": ">= 5.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const React = require('react');
-const Helmet = require('react-helmet').default;
+const { Helmet } = require('react-helmet');
 const objectEntries = require('object.entries');
 const objectAssign = require('object-assign');
 


### PR DESCRIPTION
React-Helmet [stopped supporting default exports in v6.0.0](https://github.com/nfl/react-helmet/wiki/Upgrade-from-5.x.x----6.x.x-beta). It looks like they planned this starting from v5.0.0, at which point they began exporting [both default and named exports](https://github.com/nfl/react-helmet/blob/5.0.0/src/Helmet.js) to provide a transition for dependents. 

I propose updating the required peer dependency version for react-helmet from a wildcard to any version greater than or equal to v5.0.0 and moving to named exports, which I'm guessing will cover the majority of users. If it doesn't, this will have to be revisited at a later date with some sort of module resolution logic. Alternatively, we could do that now, but this route avoids adding bloat to the codebase. 

This resolves #109.


