### PR TITLE
Remove wrong information from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,13 +47,5 @@
     "gatsby": "^2.12.1",
     "react": "*",
     "react-helmet": ">= 5.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/sidharthachatterjee/gatsby-source-datocms.git"
-  },
-  "bugs": {
-    "url": "https://github.com/sidharthachatterjee/gatsby-source-datocms/issues"
-  },
-  "homepage": "https://github.com/sidharthachatterjee/gatsby-source-datocms#readme"
+  }
 }


### PR DESCRIPTION
The package.json contained some information from a fork that was merged without removing the information.