### PR TITLE
remove drafted content from Gatsby Cloud builds

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,7 @@ const CLIENT_HEADERS = {
 };
 
 const GATSBY_CLOUD = process.env.GATSBY_CLOUD;
+const GATSBY_EXECUTING_COMMAND = process.env.gatsby_executing_command;
 
 let client, loader;
 
@@ -19,7 +20,10 @@ function createLoader({ apiToken, apiUrl, previewMode, environment }) {
   if (!client) {
     client = createClient({ apiToken, apiUrl, environment });
   }
-  return new Loader(client, GATSBY_CLOUD || previewMode);
+  return new Loader(
+    client,
+    (GATSBY_CLOUD && GATSBY_EXECUTING_COMMAND === 'develop') || previewMode,
+  );
 }
 
 function getLoader(options) {


### PR DESCRIPTION
Currently, drafted records in DatoCMS appear in both Gatsby Cloud deploy builds and previews. 

To reproduce:
- set up a Dato CMS starter site in Gatsby Cloud
- In the DatoCMS admin, go to Settings > Models > Work > Settings > Additional settings > Enable draft/published system
Create a New Record > Save
- The new record should be saved as a draft
- Trigger a new build

Actual: The drafted record appears as a page in the deploy build and the preview build.
Expected: The drafted record only appears in the preview build.

This change checks that this is both a Gatsby Cloud build, and that this is specifically a Preview build (the executing command is `gatsby develop`.