### PR TITLE
Create nodes for string fields too

### DIFF
--- a/src/hooks/sourceNodes/createNodeFromEntity/item/index.js
+++ b/src/hooks/sourceNodes/createNodeFromEntity/item/index.js
@@ -25,7 +25,7 @@ module.exports = function buildItemNode(
           node.digest = entity.meta.updatedAt;
 
           entity.itemType.fields
-            .filter(field => field.fieldType === 'text')
+            .filter(field => field.fieldType === 'string' || field.fieldType === 'text')
             .forEach(field => {
               const camelizedApiKey = camelize(field.apiKey);
 

--- a/src/hooks/sourceNodes/createTypes/item/index.js
+++ b/src/hooks/sourceNodes/createTypes/item/index.js
@@ -22,7 +22,7 @@ const fieldResolvers = {
   rich_text: require('./fields/richText'),
   seo: simpleFieldReturnCamelizedKeys('DatoCmsSeoField'),
   slug: simpleField('String'),
-  string: simpleField('String'),
+  string: require('./fields/text'),
   text: require('./fields/text'),
   video: simpleFieldReturnCamelizedKeys('DatoCmsVideoField'),
 };


### PR DESCRIPTION
This is a Feature Request in the form of a PR: I've tweaked this plugin in two spots to allow simple string fields to be `Nodes` in Gatsby, so they are open to processing. My use-case is an inline-tags-only version of `gatsby-transformer-remark`, which effectively treats the source code as a single paragraph, and returns only the innerHTML. This allows my content editors to use inline markdown tags (bold, emphasis, anchor) in simple string fields as well as multi-paragraph markdown fields. 

Thoughts?