### PR TITLE
Implement structured reporting support

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,6 +1,9 @@
 require('core-js/stable');
 require('regenerator-runtime/runtime');
 
+const onPreInit = require('./hooks/onPreInit')
+exports.onPreInit = onPreInit;
+
 const createSchemaCustomization = require('./hooks/createSchemaCustomization');
 exports.createSchemaCustomization = createSchemaCustomization;
 

--- a/src/hooks/onPreInit/errorMap.js
+++ b/src/hooks/onPreInit/errorMap.js
@@ -1,0 +1,38 @@
+
+const pluginPrefix = 'gatsby-source-datocms'
+
+function prefixId(id) {
+  return `${pluginPrefix}_${id}`
+}
+
+const ReporterLevel = {
+  Error = 'ERROR',
+}
+
+const ReporterCategory = {
+  // Error caused by user (typically, site misconfiguration)
+  User = 'USER',
+  // Error caused by DatoCMS plugin ("third party" relative to Gatsby Cloud)
+  ThirdParty = 'THIRD_PARTY',
+  // Error caused by Gatsby process
+  System = 'SYSTEM',
+}
+
+const CODES = {
+  MissingAPIToken: '10000',
+}
+
+const ERROR_MAP = {
+    [CODES.MissingAPIToken]: {
+      text: (context) => context.sourceMessage,
+      level: ReporterLevel.Error,
+      category: ReporterCategory.User,
+    },
+  }
+
+module.exports = {
+    pluginPrefix,
+    CODES,
+    prefixId,
+    ERROR_MAP,
+}

--- a/src/hooks/onPreInit/index.js
+++ b/src/hooks/onPreInit/index.js
@@ -1,0 +1,14 @@
+const { ERROR_MAP } = require("./errorMap")
+
+/**
+ * Enables structured reporting, provided the user's installed version of Gatsby has the structured reporting
+ * API.
+ * 
+ * @param {*} param0 
+ * @param {*} param1 
+ */
+module.exports = async ({ reporter }, {}) => {
+  if (reporter.setErrorMap) {
+    reporter.setErrorMap(ERROR_MAP)
+  }
+}

--- a/src/hooks/sourceNodes/index.js
+++ b/src/hooks/sourceNodes/index.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const createNodeFromEntity = require('./createNodeFromEntity');
 const destroyEntityNode = require('./destroyEntityNode');
+const { prefixId, CODES } = require('../onPreInit/errorMap')
 const Queue = require('promise-queue');
 
 const { getClient, getLoader } = require('../../utils');
@@ -26,6 +27,17 @@ module.exports = async (
   },
 ) => {
   const localeFallbacks = rawLocaleFallbacks || {};
+
+  if (!apiToken) {
+    const errorText = `API token must be provided!`
+    reporter.panic(
+      {
+        id: prefixId(CODES.MissingAPIToken),
+        context: {sourceMessage: errorText},
+      },
+      new Error(errorText),
+    )
+  }
 
   const client = getClient({ apiToken, previewMode, environment, apiUrl });
   const loader = getLoader({ apiToken, previewMode, environment, apiUrl });


### PR DESCRIPTION
> I am a GatsbyJS employee (on the Cloud side of things) - we are currently working to improve categorization of errors that users may encounter when building their site by utilizing the Structured Reporting API. This will help us improve user experience for Gatsby+DatoCMS sites built through Gatsby Cloud.

# Description

GatsbyJS' `Reporter` supports the concept of "structured reporting", where a plugin can report custom codes to Gatsby Cloud about an event that just occurred. Specifically, we are looking into categorizing all errors through this API as either `SYSTEM`, `THIRD_PARTY` or `USER` errors.

Normally, this task would be to replace anywhere there is a call to `reporter.panic` with a backwards-compatible call. However, I noticed this plugin didn't have any panic calls, so I added one in the event that a user did not provide the `apiToken`. I'm sure there are other cases, but I'll need some help identifying where else you think errors should be reported. Thanks in advance!
