### PR TITLE
Bump base64 queue size

### DIFF
--- a/src/hooks/sourceNodes/createTypes/utils/getBase64.js
+++ b/src/hooks/sourceNodes/createTypes/utils/getBase64.js
@@ -6,7 +6,7 @@ const request = require('request-promise-native');
 const resizeUrl = require('./resizeUrl');
 const queryString = require('query-string');
 
-const queue = new Queue(3, Infinity);
+const queue = new Queue(10, Infinity);
 
 function download(requestUrl, cacheDir) {
   const cacheFile = path.join(cacheDir, md5(requestUrl));


### PR DESCRIPTION
## Description

> Disclaimer: Gatsby maintainer here.

Hey folks 👋 We've been investigating performance problems of one of the sites using `gatsby-source-datocms`. And turned out the bottleneck is `base64` request queue. The problem is that it basically blocks Gatsby query queue very quickly (when multiple queries request `base64` data in multiple resolvers).

Gatsby default query concurrency is 4, so ideally this base64 queue size should be at least 2x higher than that to not block the whole query processing step.

For the subject site, it speeds up query running by a factor of 5.

## Possible follow up
Other optimizations are possible to make this process more efficient. One of such optimizations is in-flight requests cache by URL. For example, multiple queries may request `base64` variant of the same image at the same time. In this case, we send redundant network requests (that also saturate the queue).

We've seen it with very big sites, and it is pretty common actually. In-flight cache helps to mitigate this. See https://github.com/gatsbyjs/gatsby/pull/28438 for a reference.

CC @pvdz