### PR TITLE
set previewMode for users if theyre using Gatsby Cloud

### DIFF
--- a/src/hooks/createSchemaCustomization/index.js
+++ b/src/hooks/createSchemaCustomization/index.js
@@ -31,6 +31,10 @@ module.exports = async (
     )
   }
 
+  if (process.env.GATSBY_IS_PREVIEW) {
+    previewMode = process.env.GATSBY_IS_PREVIEW === `true`
+  }
+
   const loader = getLoader({ apiToken, previewMode, environment, apiUrl });
 
   const program = store.getState().program;

--- a/src/hooks/sourceNodes/index.js
+++ b/src/hooks/sourceNodes/index.js
@@ -41,6 +41,10 @@ module.exports = async (
     );
   }
 
+  if (process.env.GATSBY_IS_PREVIEW) {
+    previewMode = process.env.GATSBY_IS_PREVIEW === `true`
+  }
+
   const client = getClient({ apiToken, previewMode, environment, apiUrl });
   const loader = getLoader({ apiToken, previewMode, environment, apiUrl });
 


### PR DESCRIPTION
In Gatsby Cloud, for our new version of Preview we need the user to have `previewMode` enabled when the user is on a preview and disabled when the user is on a production build. We need to have a mechanism to check if they're currently running in a preview or not. Rather than having the user be responsible for configuring this like so:
```
{
      resolve: "gatsby-source-datocms",
      options: {
        apiToken: process.env.DATO_API_TOKEN,
        environment: process.env.DATO_ENVIRONMENT,
        previewMode: process.env.GATSBY_IS_PREVIEW,
      },
    },
```
We want to be able to rollout the new changes without asking the users to have to take action and alter their `gatsby-config` file for the fix to work.

We will check to see if the `GATSBY_IS_PREVIEW` env variable is present, which means they're on Gatsby Cloud hosting, and then check its value to determine if we're looking at a preview or not.