### PR TITLE
change time from 2 days to 1 week for content sync

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -57,7 +57,7 @@ async function getLoader({ cache, loadStateFromCache, ...options }) {
   return loader;
 }
 
-const ONE_HOUR = 1000 * 60 * 60; // ms * sec * min
+const ONE_DAY = 1000 * 60 * 60 * 24; // ms * sec * min * hour
 let nodeManifestWarningWasLogged;
 
 const datocmsCreateNodeManifest = ({ node, context }) => {
@@ -76,8 +76,8 @@ const datocmsCreateNodeManifest = ({ node, context }) => {
       const nodeWasRecentlyUpdated =
         Date.now() - new Date(node.entityPayload.meta.updated_at).getTime() <=
         // Default to only create manifests for items updated in last 48 hours
-        ((process.env.CONTENT_SYNC_DATOCMS_HOURS_SINCE_ENTRY_UPDATE ||
-          48) * ONE_HOUR);
+        ((process.env.CONTENT_SYNC_DATOCMS_DAYS_SINCE_ENTRY_UPDATE ||
+          7) * ONE_DAY);
           
       // We need to create manifests on cold builds, this prevents from creating many more
       // manifests than we actually need


### PR DESCRIPTION
We've realized that our previous estimation of only creating node manifests for nodes updated in the past 2 days wasn't enough, this led users to not be able to preview some content on cold builds from the datocms extension. In the near future we're going to optimize the node manifest creation and then by default create manifests for all nodes on cold builds. But in the meantime we want to just increase the updatedAt to create manifests for all content updated in the past week (rather than the past 2 days).