### PR TITLE
Allow gatsby-plugin-image v2 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "license": "ISC",
   "peerDependencies": {
     "gatsby": "^2.12.1 || ^3.0.0 || ^4.0.0",
-    "gatsby-plugin-image": "^1.0.0",
+    "gatsby-plugin-image": "^1.0.0 || ^2.0.0",
     "react": "*",
     "react-helmet": ">= 5.0.0"
   },


### PR DESCRIPTION
We have been using gatsby-plugin-image@2.1.0 with gatsby-source-datocms@3.0.10 and it has worked really well for us so far.

Looking at the [CHANGELOG for gatsby-plugin-image@2.2.0](https://github.com/gatsbyjs/gatsby/blob/gatsby-plugin-image%402.2.0/packages/gatsby-plugin-image/CHANGELOG.md) the only thing I can see that prompts a major version bump is https://github.com/gatsbyjs/gatsby/pull/32544 (basically when using multiple sources you need to include `gatsby-plugin-image` in your `gatsby-config.js`) but the [commit itself](https://github.com/gatsbyjs/gatsby/commit/3bf4f101d55df27859c0fbe7b7c1c399ce0f99e4) isn't marked as a breaking change. So I don't really know. Maybe the major version bump was for Gatsby to be able to say that Gatsby v4 requires v2+ of `gatsby-plugin-image`? 🤷‍♂️  

Either way, I manually checled the diff between 1.14.2 and 2.2.0 and I can't see any reason for the major version bump other than the above. The diff is basically only version bumps to dependencies, devDependencies and peerDependencies.

This PR would allow more flexibility for consumers of `gatsby-source-datocms`.