### PR TITLE
feat: add Gatsby image cdn resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,9 +520,14 @@ If you need to get every locale for a specific field, you can use the `_all<FIEL
 
 ## Integration with Gatsby Image
 
-### For Gatsby v3+ (currently in beta)
+### For Gatsby v4.10.0+
 
-This plugin is compatible with the new [gatsby-plugin-image](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/) and the `<GatsbyImage />` component released with Gatsby v3:
+This plugin is compatible with [Gatsby's Image CDN](https://gatsby.dev/img).
+To use this new feature follow the [docs below](#for-gatsby-v3) but instead of querying the `gatsbyImageData` field, query the `gatsbyImage` field.
+
+### For Gatsby v3+
+
+This plugin is compatible with [gatsby-plugin-image](https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-plugin-image/) and the `<GatsbyImage />` component released with Gatsby v3:
 
 ```jsx
 import React from 'react';

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "datocms-client": ">=3.5.4",
     "datocms-structured-text-utils": "^1.0.13",
     "gatsby-core-utils": "^3.1.0",
-    "gatsby-plugin-utils": "^2.0.0",
+    "gatsby-plugin-utils": "^3.4.0-next.3",
     "humps": ">=2.0.1",
     "imgix-url-params": ">=11.11.2",
     "json-stringify-safe": ">=5.0.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "datocms-client": ">=3.5.4",
     "datocms-structured-text-utils": "^1.0.13",
     "gatsby-core-utils": "^3.1.0",
-    "gatsby-plugin-utils": "^3.4.0-next.3",
+    "gatsby-plugin-utils": "^3.4.0",
     "humps": ">=2.0.1",
     "imgix-url-params": ">=11.11.2",
     "json-stringify-safe": ">=5.0.1",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -2,6 +2,10 @@ require('core-js/stable');
 require('regenerator-runtime/runtime');
 const { ERROR_MAP } = require('./errorMap');
 
+const {
+  polyfillImageServiceDevRoutes,
+} = require('gatsby-plugin-utils/polyfill-remote-file');
+
 const withForcedPreviewMode = hook => {
   return (context, options) => {
     return hook(context, {
@@ -55,4 +59,8 @@ exports.onPreInit = async ({ reporter }) => {
   if (!onPluginInitSupported && reporter.setErrorMap) {
     reporter.setErrorMap(ERROR_MAP);
   }
+};
+
+exports.onCreateDevServer = ({ app }) => {
+  polyfillImageServiceDevRoutes(app);
 };

--- a/src/hooks/sourceNodes/createNodeFromEntity/upload/index.js
+++ b/src/hooks/sourceNodes/createNodeFromEntity/upload/index.js
@@ -18,6 +18,6 @@ module.exports = function buildUploadNode(
     node.width = node.entityPayload.attributes.width;
     node.height = node.entityPayload.attributes.height;
     node.url = node.entityPayload.attributes.url;
-    node.placeholderUrl = node.url + `?w=20`; // tiny image transformed by imgix
+    node.placeholderUrl = node.url + `?w=%width%&h=%height%`;
   });
 };

--- a/src/hooks/sourceNodes/createNodeFromEntity/upload/index.js
+++ b/src/hooks/sourceNodes/createNodeFromEntity/upload/index.js
@@ -15,8 +15,9 @@ module.exports = function buildUploadNode(
     // Gatsby Image CDN fields:
     node.mimeType = node.entityPayload.attributes.mime_type;
     node.filename = node.entityPayload.attributes.filename;
-    node.url = node.entityPayload.attributes.url;
     node.width = node.entityPayload.attributes.width;
     node.height = node.entityPayload.attributes.height;
+    node.url = node.entityPayload.attributes.url;
+    node.placeholderUrl = node.url + `?w=20`; // tiny image transformed by imgix
   });
 };

--- a/src/hooks/sourceNodes/createNodeFromEntity/upload/index.js
+++ b/src/hooks/sourceNodes/createNodeFromEntity/upload/index.js
@@ -11,5 +11,13 @@ module.exports = function buildUploadNode(
     node.entityPayload = entity.payload;
     node.imgixHost = imgixHost;
     node.digest = entity.path + entity.updatedAt;
+
+    // Gatsby Image CDN fields:
+    node.mimeType = node.entityPayload.attributes.mime_type;
+    node.filename = node.entityPayload.attributes.filename;
+    node.url = node.entityPayload.attributes.url;
+    node.width = node.entityPayload.attributes.width;
+    node.height = node.entityPayload.attributes.height;
+    console.log(JSON.stringify(node, null, 2));
   });
 };

--- a/src/hooks/sourceNodes/createNodeFromEntity/upload/index.js
+++ b/src/hooks/sourceNodes/createNodeFromEntity/upload/index.js
@@ -18,6 +18,5 @@ module.exports = function buildUploadNode(
     node.url = node.entityPayload.attributes.url;
     node.width = node.entityPayload.attributes.width;
     node.height = node.entityPayload.attributes.height;
-    console.log(JSON.stringify(node, null, 2));
   });
 };

--- a/src/hooks/sourceNodes/createTypes/fieldTypes/DatoCmsFileField.js
+++ b/src/hooks/sourceNodes/createTypes/fieldTypes/DatoCmsFileField.js
@@ -1,18 +1,29 @@
+const {
+  addRemoteFilePolyfillInterface,
+} = require('gatsby-plugin-utils/polyfill-remote-file');
+
 const buildAssetFields = require('../utils/buildAssetFields');
 
 module.exports = ({ actions, schema, cache }) => {
   actions.createTypes([
-    schema.buildObjectType({
-      name: 'DatoCmsFileField',
-      extensions: { infer: false },
-      fields: {
-        ...buildAssetFields({ cache }),
-        alt: 'String',
-        title: 'String',
-        customData: 'JSON',
-        focalPoint: 'DatoCmsFocalPoint',
+    addRemoteFilePolyfillInterface(
+      schema.buildObjectType({
+        name: 'DatoCmsFileField',
+        extensions: { infer: false },
+        fields: {
+          ...buildAssetFields({ cache }),
+          alt: 'String',
+          title: 'String',
+          customData: 'JSON',
+          focalPoint: 'DatoCmsFocalPoint',
+        },
+        interfaces: ['RemoteFile'],
+      }),
+      {
+        schema,
+        actions,
       },
-    }),
+    ),
     schema.buildObjectType({
       name: 'DatoCmsFocalPoint',
       extensions: { infer: false },

--- a/src/hooks/sourceNodes/createTypes/upload/DatoCmsAsset.js
+++ b/src/hooks/sourceNodes/createTypes/upload/DatoCmsAsset.js
@@ -1,15 +1,25 @@
+const {
+  addRemoteFilePolyfillInterface,
+} = require('gatsby-plugin-utils/polyfill-remote-file');
+
 const buildAssetFields = require('../utils/buildAssetFields');
 
 module.exports = ({ actions, schema, store, cache, generateType }) => {
   actions.createTypes([
-    schema.buildObjectType({
-      name: generateType('Asset'),
-      extensions: { infer: false },
-      fields: {
-        ...buildAssetFields({ cache }),
+    addRemoteFilePolyfillInterface(
+      schema.buildObjectType({
+        name: generateType('Asset'),
+        extensions: { infer: false },
+        fields: {
+          ...buildAssetFields({ cache }),
+        },
+        interfaces: ['Node', 'RemoteFile'],
+      }),
+      {
+        schema,
+        actions,
       },
-      interfaces: ['Node'],
-    }),
+    ),
     schema.buildEnumType({
       name: 'DatoCmsAssetVideoThumbnailFormat',
       values: {

--- a/src/hooks/sourceNodes/createTypes/utils/buildAssetFields.js
+++ b/src/hooks/sourceNodes/createTypes/utils/buildAssetFields.js
@@ -21,8 +21,6 @@ const resolveUsingEntityPayloadAttribute = (
 module.exports = function({ cache }) {
   return {
     size: resolveUsingEntityPayloadAttribute('size', { type: 'Int' }),
-    width: resolveUsingEntityPayloadAttribute('width', { type: 'Int' }),
-    height: resolveUsingEntityPayloadAttribute('height', { type: 'Int' }),
     path: resolveUsingEntityPayloadAttribute('path', { type: 'String' }),
     format: resolveUsingEntityPayloadAttribute('format', { type: 'String' }),
     isImage: resolveUsingEntityPayloadAttribute('is_image', {
@@ -37,9 +35,6 @@ module.exports = function({ cache }) {
     smartTags: resolveUsingEntityPayloadAttribute('smart_tags', {
       type: '[String]',
     }),
-    filename: resolveUsingEntityPayloadAttribute('filename', {
-      type: 'String',
-    }),
     basename: resolveUsingEntityPayloadAttribute('basename', {
       type: 'String',
     }),
@@ -48,9 +43,6 @@ module.exports = function({ cache }) {
       { type: 'JSON' },
       true,
     ),
-    mimeType: resolveUsingEntityPayloadAttribute('mime_type', {
-      type: 'String',
-    }),
     colors: resolveUsingEntityPayloadAttribute('colors', {
       type: '[DatoCmsColorField]',
     }),

--- a/test/fixtures/graphql-responses/csv-asset.json
+++ b/test/fixtures/graphql-responses/csv-asset.json
@@ -29,7 +29,8 @@
       "newFluidH": null,
       "newFluidWH": null,
       "newFixedSmallerThanOriginal": null,
-      "newFluidWSmallerThanOriginal": null
+      "newFluidWSmallerThanOriginal": null,
+      "imageCDN": null
     }
   }
 }

--- a/test/fixtures/graphql-responses/item.json
+++ b/test/fixtures/graphql-responses/item.json
@@ -260,6 +260,31 @@
           },
           "width": 30,
           "height": 23
+        },
+        "imageCDN": {
+          "images": {
+            "sources": [
+              {
+                "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWF2aWYmcT03NQ==/plant.avif 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWF2aWYmcT03NQ==/plant.avif 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1hdmlmJnE9NzU=/plant.avif 100w",
+                "type": "image/avif",
+                "sizes": "(min-width: 100px) 100px, 100vw"
+              },
+              {
+                "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPXdlYnAmcT03NQ==/plant.webp 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPXdlYnAmcT03NQ==/plant.webp 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT13ZWJwJnE9NzU=/plant.webp 100w",
+                "type": "image/webp",
+                "sizes": "(min-width: 100px) 100px, 100vw"
+              }
+            ],
+            "fallback": {
+              "src": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg",
+              "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWpwZyZxPTc1/plant.jpg 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1qcGcmcT03NQ==/plant.jpg 100w",
+              "sizes": "(min-width: 100px) 100px, 100vw"
+            }
+          },
+          "layout": "constrained",
+          "width": 100,
+          "height": 75,
+          "backgroundColor": "rgb(120,168,72)"
         }
       },
       "_allSingleAssetLocales": [
@@ -468,6 +493,31 @@
               },
               "width": 30,
               "height": 23
+            },
+            "imageCDN": {
+              "images": {
+                "sources": [
+                  {
+                    "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWF2aWYmcT03NQ==/plant.avif 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWF2aWYmcT03NQ==/plant.avif 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1hdmlmJnE9NzU=/plant.avif 100w",
+                    "type": "image/avif",
+                    "sizes": "(min-width: 100px) 100px, 100vw"
+                  },
+                  {
+                    "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPXdlYnAmcT03NQ==/plant.webp 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPXdlYnAmcT03NQ==/plant.webp 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT13ZWJwJnE9NzU=/plant.webp 100w",
+                    "type": "image/webp",
+                    "sizes": "(min-width: 100px) 100px, 100vw"
+                  }
+                ],
+                "fallback": {
+                  "src": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg",
+                  "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWpwZyZxPTc1/plant.jpg 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1qcGcmcT03NQ==/plant.jpg 100w",
+                  "sizes": "(min-width: 100px) 100px, 100vw"
+                }
+              },
+              "layout": "constrained",
+              "width": 100,
+              "height": 75,
+              "backgroundColor": "rgb(120,168,72)"
             }
           }
         },
@@ -516,7 +566,8 @@
             "newFluidH": null,
             "newFluidWH": null,
             "newFixedSmallerThanOriginal": null,
-            "newFluidWSmallerThanOriginal": null
+            "newFluidWSmallerThanOriginal": null,
+            "imageCDN": null
           }
         }
       ],
@@ -564,7 +615,8 @@
           "newFluidH": null,
           "newFluidWH": null,
           "newFixedSmallerThanOriginal": null,
-          "newFluidWSmallerThanOriginal": null
+          "newFluidWSmallerThanOriginal": null,
+          "imageCDN": null
         },
         {
           "alt": "English alt caption",
@@ -768,6 +820,31 @@
             },
             "width": 30,
             "height": 23
+          },
+          "imageCDN": {
+            "images": {
+              "sources": [
+                {
+                  "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWF2aWYmcT03NQ==/plant.avif 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWF2aWYmcT03NQ==/plant.avif 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1hdmlmJnE9NzU=/plant.avif 100w",
+                  "type": "image/avif",
+                  "sizes": "(min-width: 100px) 100px, 100vw"
+                },
+                {
+                  "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPXdlYnAmcT03NQ==/plant.webp 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPXdlYnAmcT03NQ==/plant.webp 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT13ZWJwJnE9NzU=/plant.webp 100w",
+                  "type": "image/webp",
+                  "sizes": "(min-width: 100px) 100px, 100vw"
+                }
+              ],
+              "fallback": {
+                "src": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg",
+                "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWpwZyZxPTc1/plant.jpg 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1qcGcmcT03NQ==/plant.jpg 100w",
+                "sizes": "(min-width: 100px) 100px, 100vw"
+              }
+            },
+            "layout": "constrained",
+            "width": 100,
+            "height": 75,
+            "backgroundColor": "rgb(120,168,72)"
           }
         }
       ],
@@ -818,7 +895,8 @@
               "newFluidH": null,
               "newFluidWH": null,
               "newFixedSmallerThanOriginal": null,
-              "newFluidWSmallerThanOriginal": null
+              "newFluidWSmallerThanOriginal": null,
+              "imageCDN": null
             },
             {
               "alt": "English alt caption",
@@ -1022,6 +1100,31 @@
                 },
                 "width": 30,
                 "height": 23
+              },
+              "imageCDN": {
+                "images": {
+                  "sources": [
+                    {
+                      "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWF2aWYmcT03NQ==/plant.avif 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWF2aWYmcT03NQ==/plant.avif 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1hdmlmJnE9NzU=/plant.avif 100w",
+                      "type": "image/avif",
+                      "sizes": "(min-width: 100px) 100px, 100vw"
+                    },
+                    {
+                      "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPXdlYnAmcT03NQ==/plant.webp 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPXdlYnAmcT03NQ==/plant.webp 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT13ZWJwJnE9NzU=/plant.webp 100w",
+                      "type": "image/webp",
+                      "sizes": "(min-width: 100px) 100px, 100vw"
+                    }
+                  ],
+                  "fallback": {
+                    "src": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg",
+                    "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWpwZyZxPTc1/plant.jpg 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1qcGcmcT03NQ==/plant.jpg 100w",
+                    "sizes": "(min-width: 100px) 100px, 100vw"
+                  }
+                },
+                "layout": "constrained",
+                "width": 100,
+                "height": 75,
+                "backgroundColor": "rgb(120,168,72)"
               }
             }
           ]
@@ -1061,7 +1164,8 @@
               "newFluidH": null,
               "newFluidWH": null,
               "newFixedSmallerThanOriginal": null,
-              "newFluidWSmallerThanOriginal": null
+              "newFluidWSmallerThanOriginal": null,
+              "imageCDN": null
             },
             {
               "alt": null,
@@ -1106,7 +1210,8 @@
               "newFluidH": null,
               "newFluidWH": null,
               "newFixedSmallerThanOriginal": null,
-              "newFluidWSmallerThanOriginal": null
+              "newFluidWSmallerThanOriginal": null,
+              "imageCDN": null
             }
           ]
         }

--- a/test/fixtures/graphql-responses/mp4-asset.json
+++ b/test/fixtures/graphql-responses/mp4-asset.json
@@ -40,7 +40,8 @@
       "newFluidH": null,
       "newFluidWH": null,
       "newFixedSmallerThanOriginal": null,
-      "newFluidWSmallerThanOriginal": null
+      "newFluidWSmallerThanOriginal": null,
+      "imageCDN": null
     }
   }
 }

--- a/test/fixtures/graphql-responses/png-asset.json
+++ b/test/fixtures/graphql-responses/png-asset.json
@@ -197,6 +197,31 @@
         },
         "width": 30,
         "height": 23
+      },
+      "imageCDN": {
+        "images": {
+          "sources": [
+            {
+              "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWF2aWYmcT03NQ==/plant.avif 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWF2aWYmcT03NQ==/plant.avif 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1hdmlmJnE9NzU=/plant.avif 100w",
+              "type": "image/avif",
+              "sizes": "(min-width: 100px) 100px, 100vw"
+            },
+            {
+              "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPXdlYnAmcT03NQ==/plant.webp 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPXdlYnAmcT03NQ==/plant.webp 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT13ZWJwJnE9NzU=/plant.webp 100w",
+              "type": "image/webp",
+              "sizes": "(min-width: 100px) 100px, 100vw"
+            }
+          ],
+          "fallback": {
+            "src": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg",
+            "srcSet": "/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0yNSZoPTE5JmZtPWpwZyZxPTc1/plant.jpg 25w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz01MCZoPTM4JmZtPWpwZyZxPTc1/plant.jpg 50w,/_gatsby/image/aHR0cHM6Ly93d3cuZGF0b2Ntcy1hc3NldHMuY29tLzM0NzIzLzE2MjA2Mjk2MzgtcGxhbnQuanBlZw==/dz0xMDAmaD03NSZmbT1qcGcmcT03NQ==/plant.jpg 100w",
+            "sizes": "(min-width: 100px) 100px, 100vw"
+          }
+        },
+        "layout": "constrained",
+        "width": 100,
+        "height": 75,
+        "backgroundColor": "rgb(120,168,72)"
       }
     }
   }

--- a/test/graphql.test.js
+++ b/test/graphql.test.js
@@ -272,7 +272,7 @@ const assetFields = /* GraphQL */ `
     newFluidWSmallerThanOriginal: gatsbyImageData(width: 30, layout: CONSTRAINED)
   `;
 
-const fileFields = `alt title customData ${assetFields}`;
+const fileFields = /* GraphQL */ `alt title customData ${assetFields}`;
 
 Suite('assets', async () => {
   assertGraphQLResponseEqualToSnapshot(

--- a/test/graphql.test.js
+++ b/test/graphql.test.js
@@ -278,19 +278,19 @@ Suite('assets', async () => {
   assertGraphQLResponseEqualToSnapshot(
     'png-asset',
     await executeQuery(
-      `{ datoCmsAsset(originalId: {eq: "2637142"}) { ${assetFields} } }`,
+      /* GraphQL */ `{ datoCmsAsset(originalId: {eq: "2637142"}) { ${assetFields} } }`,
     ),
   );
   assertGraphQLResponseEqualToSnapshot(
     'mp4-asset',
     await executeQuery(
-      `{ datoCmsAsset(originalId: {eq: "2637250"}) { ${assetFields} } }`,
+      /* GraphQL */ `{ datoCmsAsset(originalId: {eq: "2637250"}) { ${assetFields} } }`,
     ),
   );
   assertGraphQLResponseEqualToSnapshot(
     'csv-asset',
     await executeQuery(
-      `{ datoCmsAsset(originalId: {eq: "2637251"}) { ${assetFields} } }`,
+      /* GraphQL */ `{ datoCmsAsset(originalId: {eq: "2637251"}) { ${assetFields} } }`,
     ),
   );
 });

--- a/test/graphql.test.js
+++ b/test/graphql.test.js
@@ -17,9 +17,9 @@ Suite.before(async () => {
 });
 
 Suite('focalPoints', async () => {
-  const result = await executeQuery(`
+  const result = await executeQuery(/* GraphQL */ `
     {
-      datoCmsArticle(originalId: {eq: "7364344"}) {
+      datoCmsArticle(originalId: { eq: "7364344" }) {
         singleAsset {
           focalPoint {
             x
@@ -27,13 +27,48 @@ Suite('focalPoints', async () => {
           }
           url
 
-          urlWithFocalPoint: url(imgixParams: { w: "150", h: "40", fit: "crop" })
-          fluid(maxWidth: 150, imgixParams: { w: "150", h: "40", fit: "crop" }) { tracedSVG base64 src srcSet }
-          blurhashFluid: fluid(maxWidth: 150, forceBlurhash: true, imgixParams: { w: "150", h: "40", fit: "crop" }) { tracedSVG base64 src srcSet }
+          urlWithFocalPoint: url(
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          )
+          fluid(
+            maxWidth: 150
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          ) {
+            tracedSVG
+            base64
+            src
+            srcSet
+          }
+          blurhashFluid: fluid(
+            maxWidth: 150
+            forceBlurhash: true
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          ) {
+            tracedSVG
+            base64
+            src
+            srcSet
+          }
 
-          tracedSvgFluidGatsbyImage: gatsbyImageData(width: 150, placeholder: TRACED_SVG, layout: CONSTRAINED, imgixParams: { w: "150", h: "40", fit: "crop" })
-          dominantSvgFluidGatsbyImage: gatsbyImageData(width: 150, placeholder: DOMINANT_COLOR, layout: CONSTRAINED, imgixParams: { w: "150", h: "40", fit: "crop" })
-          blurhashFluidGatsbyImage: gatsbyImageData(width: 150, forceBlurhash: true, placeholder: BLURRED, layout: CONSTRAINED, imgixParams: { w: "150", h: "40", fit: "crop" })
+          tracedSvgFluidGatsbyImage: gatsbyImageData(
+            width: 150
+            placeholder: TRACED_SVG
+            layout: CONSTRAINED
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          )
+          dominantSvgFluidGatsbyImage: gatsbyImageData(
+            width: 150
+            placeholder: DOMINANT_COLOR
+            layout: CONSTRAINED
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          )
+          blurhashFluidGatsbyImage: gatsbyImageData(
+            width: 150
+            forceBlurhash: true
+            placeholder: BLURRED
+            layout: CONSTRAINED
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          )
         }
         assetGallery {
           focalPoint {
@@ -41,16 +76,51 @@ Suite('focalPoints', async () => {
             y
           }
           url
-          urlWithFocalPoint: url(imgixParams: { w: "150", h: "40", fit: "crop" })
-          fluid(maxWidth: 150, imgixParams: { w: "150", h: "40", fit: "crop" }) { tracedSVG base64 src srcSet }
-          blurhashFluid: fluid(maxWidth: 150, forceBlurhash: true, imgixParams: { w: "150", h: "40", fit: "crop" }) { tracedSVG base64 src srcSet }
+          urlWithFocalPoint: url(
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          )
+          fluid(
+            maxWidth: 150
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          ) {
+            tracedSVG
+            base64
+            src
+            srcSet
+          }
+          blurhashFluid: fluid(
+            maxWidth: 150
+            forceBlurhash: true
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          ) {
+            tracedSVG
+            base64
+            src
+            srcSet
+          }
 
-          tracedSvgFluidGatsbyImage: gatsbyImageData(width: 150, placeholder: TRACED_SVG, layout: CONSTRAINED, imgixParams: { w: "150", h: "40", fit: "crop" })
-          dominantSvgFluidGatsbyImage: gatsbyImageData(width: 150, placeholder: DOMINANT_COLOR, layout: CONSTRAINED, imgixParams: { w: "150", h: "40", fit: "crop" })
-          blurhashFluidGatsbyImage: gatsbyImageData(width: 150, forceBlurhash: true, placeholder: BLURRED, layout: CONSTRAINED, imgixParams: { w: "150", h: "40", fit: "crop" })
+          tracedSvgFluidGatsbyImage: gatsbyImageData(
+            width: 150
+            placeholder: TRACED_SVG
+            layout: CONSTRAINED
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          )
+          dominantSvgFluidGatsbyImage: gatsbyImageData(
+            width: 150
+            placeholder: DOMINANT_COLOR
+            layout: CONSTRAINED
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          )
+          blurhashFluidGatsbyImage: gatsbyImageData(
+            width: 150
+            forceBlurhash: true
+            placeholder: BLURRED
+            layout: CONSTRAINED
+            imgixParams: { w: "150", h: "40", fit: "crop" }
+          )
         }
       }
-      noFocalPoint: datoCmsArticle(originalId: {eq: "7364346"}) {
+      noFocalPoint: datoCmsArticle(originalId: { eq: "7364346" }) {
         singleAsset {
           focalPoint {
             x
@@ -58,43 +128,84 @@ Suite('focalPoints', async () => {
           }
         }
       }
-    }`);
+    }
+  `);
 
   assertGraphQLResponseEqualToSnapshot('focal-point', result);
 });
 
 Suite('auto=format', async () => {
-  const result = await executeQuery(`
+  const result = await executeQuery(/* GraphQL */ `
     {
-      datoCmsArticle(originalId: {eq: "7364344"}) {
+      datoCmsArticle(originalId: { eq: "7364344" }) {
         singleAsset {
           noFormatUrl: url(imgixParams: { maxW: 200 })
-          noFormatFixed: fixed(width: 300, imgixParams: { maxW: 200 }) { src srcSet }
-          noFormatFluid: fluid(maxWidth: 140, imgixParams: { w: "140", h: "40", fit: "crop", maxW: 200 }) { src srcSet }
+          noFormatFixed: fixed(width: 300, imgixParams: { maxW: 200 }) {
+            src
+            srcSet
+          }
+          noFormatFluid: fluid(
+            maxWidth: 140
+            imgixParams: { w: "140", h: "40", fit: "crop", maxW: 200 }
+          ) {
+            src
+            srcSet
+          }
 
           pngFormatUrl: url(imgixParams: { fm: "png", maxW: 200 })
-          pngFormatFixed: fixed(width: 300, imgixParams: { fm: "png", maxW: 200 }) { src srcSet }
-          pngFormatFluid: fluid(maxWidth: 140, imgixParams: { w: "140", h: "40", fit: "crop", fm: "png", maxW: 200 }) { src srcSet }
+          pngFormatFixed: fixed(
+            width: 300
+            imgixParams: { fm: "png", maxW: 200 }
+          ) {
+            src
+            srcSet
+          }
+          pngFormatFluid: fluid(
+            maxWidth: 140
+            imgixParams: {
+              w: "140"
+              h: "40"
+              fit: "crop"
+              fm: "png"
+              maxW: 200
+            }
+          ) {
+            src
+            srcSet
+          }
         }
       }
 
-      assetWhichIsNotAnImage: datoCmsAsset(originalId: {eq: "2637251"}) {
+      assetWhichIsNotAnImage: datoCmsAsset(originalId: { eq: "2637251" }) {
         url
-        noFormatFluid: fluid(maxWidth: 140) { src srcSet }
+        noFormatFluid: fluid(maxWidth: 140) {
+          src
+          srcSet
+        }
       }
 
-      assetWhichIsSvg: datoCmsAsset(originalId: {eq: "10015565"}) {
+      assetWhichIsSvg: datoCmsAsset(originalId: { eq: "10015565" }) {
         url
-        noFormatFluid: fluid(maxWidth: 140) { src srcSet }
+        noFormatFluid: fluid(maxWidth: 140) {
+          src
+          srcSet
+        }
       }
 
-      assetWhichIsNotAnImageThroughRecord: datoCmsArticle(originalId: {eq: "7364344"}, locale: { eq: "it" }) {
+      assetWhichIsNotAnImageThroughRecord: datoCmsArticle(
+        originalId: { eq: "7364344" }
+        locale: { eq: "it" }
+      ) {
         assetGallery {
           url
-          noFormatFluid: fluid(maxWidth: 140) { src srcSet }
+          noFormatFluid: fluid(maxWidth: 140) {
+            src
+            srcSet
+          }
         }
       }
-    }`);
+    }
+  `);
 
   assertGraphQLResponseEqualToSnapshot('auto-format', result);
 });
@@ -102,25 +213,39 @@ Suite('auto=format', async () => {
 Suite('force blurhash', async () => {
   assertGraphQLResponseEqualToSnapshot(
     'blurhash',
-    await executeQuery(
-      `{
-          datoCmsAsset(originalId: {eq: "2643791"}) {
-            fixed(width: 300) { base64 }
-            fluid(maxWidth: 300) { base64 }
-            forceBlurhashFixed: fixed(width: 300, forceBlurhash: true) { base64 }
-            forceBlurhashFluid: fluid(maxWidth: 300, forceBlurhash: true) { base64 }
+    await executeQuery(/* GraphQL */ `
+      {
+        datoCmsAsset(originalId: { eq: "2643791" }) {
+          fixed(width: 300) {
+            base64
           }
+          fluid(maxWidth: 300) {
+            base64
+          }
+          forceBlurhashFixed: fixed(width: 300, forceBlurhash: true) {
+            base64
+          }
+          forceBlurhashFluid: fluid(maxWidth: 300, forceBlurhash: true) {
+            base64
+          }
+        }
 
-          assetWhichIsSvg: datoCmsAsset(originalId: {eq: "10015565"}) {
-            fixed(width: 300) { base64 tracedSVG }
-            fluid(maxWidth: 300) { base64 tracedSVG }
+        assetWhichIsSvg: datoCmsAsset(originalId: { eq: "10015565" }) {
+          fixed(width: 300) {
+            base64
+            tracedSVG
           }
-       }`,
-    ),
+          fluid(maxWidth: 300) {
+            base64
+            tracedSVG
+          }
+        }
+      }
+    `),
   );
 });
 
-const assetFields = `
+const assetFields = /* GraphQL */ `
     size width height path format isImage notes author copyright tags
     smartTags filename basename exifInfo mimeType blurhash
     originalId url createdAt
@@ -173,90 +298,92 @@ Suite('assets', async () => {
 Suite('sortable collection', async () => {
   assertGraphQLResponseEqualToSnapshot(
     'sortable-position',
-    await executeQuery(`
-    {
-      datoCmsSecondaryModel(originalId: {eq: "7364459"}) {
-        position
+    await executeQuery(/* GraphQL */ `
+      {
+        datoCmsSecondaryModel(originalId: { eq: "7364459" }) {
+          position
+        }
       }
-    }
-  `),
+    `),
   );
 });
 
 Suite('site', async () => {
   assertGraphQLResponseEqualToSnapshot(
     'site',
-    await executeQuery(`
-    {
-      enSite: datoCmsSite(locale: {eq: "en"}) {
-        __typename
-        id
-        originalId
-        name
-        locale
-        locales
-        domain
-        internalDomain
-        noIndex
-        globalSeo {
-          siteName
-          titleSuffix
-          twitterAccount
-          facebookPageUrl
-          fallbackSeo {
-            title
-            description
-            twitterCard
-            image {
-              path
-              url
+    await executeQuery(/* GraphQL */ `
+      {
+        enSite: datoCmsSite(locale: { eq: "en" }) {
+          __typename
+          id
+          originalId
+          name
+          locale
+          locales
+          domain
+          internalDomain
+          noIndex
+          globalSeo {
+            siteName
+            titleSuffix
+            twitterAccount
+            facebookPageUrl
+            fallbackSeo {
+              title
+              description
+              twitterCard
+              image {
+                path
+                url
+              }
             }
           }
-        }
-        faviconMetaTags {
-          tags
-        }
-      }
-      itSite: datoCmsSite(locale: {eq: "it"}) {
-        __typename
-        id
-        originalId
-        name
-        locale
-        locales
-        domain
-        internalDomain
-        noIndex
-        globalSeo {
-          siteName
-          titleSuffix
-          twitterAccount
-          facebookPageUrl
-          fallbackSeo {
-            title
-            description
-            twitterCard
-            image {
-              path
-              url
-            }
+          faviconMetaTags {
+            tags
           }
         }
-        faviconMetaTags {
-          tags
+        itSite: datoCmsSite(locale: { eq: "it" }) {
+          __typename
+          id
+          originalId
+          name
+          locale
+          locales
+          domain
+          internalDomain
+          noIndex
+          globalSeo {
+            siteName
+            titleSuffix
+            twitterAccount
+            facebookPageUrl
+            fallbackSeo {
+              title
+              description
+              twitterCard
+              image {
+                path
+                url
+              }
+            }
+          }
+          faviconMetaTags {
+            tags
+          }
         }
       }
-    }
-  `),
+    `),
   );
 });
 
 Suite('tree collections', async () => {
   assertGraphQLResponseEqualToSnapshot(
     'tree',
-    await executeQuery(`
+    await executeQuery(/* GraphQL */ `
       {
-        allDatoCmsHierarchical(filter: {root: {eq: true}, locale: {eq: "en"}}) {
+        allDatoCmsHierarchical(
+          filter: { root: { eq: true }, locale: { eq: "en" } }
+        ) {
           nodes {
             id
             title
@@ -288,7 +415,7 @@ Suite('tree collections', async () => {
 });
 
 Suite('items', async () => {
-  const query = `
+  const query = /* GraphQL */ `
     {
       enArticle: datoCmsArticle(originalId: {eq: "7364344"}, locale: {eq: "en"}) {
         __typename
@@ -646,68 +773,68 @@ Suite('items', async () => {
 Suite('multiple instances', async () => {
   assertGraphQLResponseEqualToSnapshot(
     'multipleInstances',
-    await executeQuery(
-      `{
-          datoCmsAlternativeSite(locale: {eq: "en"}) {
-            __typename
-            id
-            originalId
+    await executeQuery(/* GraphQL */ `
+      {
+        datoCmsAlternativeSite(locale: { eq: "en" }) {
+          __typename
+          id
+          originalId
+          name
+          locale
+          locales
+          domain
+          internalDomain
+          noIndex
+          globalSeo {
+            siteName
+            titleSuffix
+            twitterAccount
+            facebookPageUrl
+            fallbackSeo {
+              title
+              description
+              twitterCard
+              image {
+                path
+                url
+              }
+            }
+          }
+          faviconMetaTags {
+            tags
+          }
+        }
+        allDatoCmsAlternativeModel {
+          nodes {
             name
+          }
+        }
+        allDatoCmsAlternativeAsset {
+          nodes {
+            url
+          }
+        }
+        allDatoCmsAlternativeArticle {
+          nodes {
+            __typename
             locale
-            locales
-            domain
-            internalDomain
-            noIndex
-            globalSeo {
-              siteName
-              titleSuffix
-              twitterAccount
-              facebookPageUrl
-              fallbackSeo {
-                title
-                description
-                twitterCard
-                image {
-                  path
-                  url
-                }
+            originalId
+            id
+            name
+            seo {
+              image {
+                path
               }
             }
-            faviconMetaTags {
-              tags
-            }
-          }
-          allDatoCmsAlternativeModel {
-            nodes {
-              name
-            }
-          }
-          allDatoCmsAlternativeAsset {
-            nodes {
-              url
-            }
-          }
-          allDatoCmsAlternativeArticle {
-            nodes {
+            seoMetaTags {
               __typename
-              locale
-              originalId
+              tags
               id
-              name
-              seo {
-                image {
-                  path
-                }
-              }
-              seoMetaTags {
-                __typename
-                tags
-                id
-              }
             }
           }
-       }`,
-    ),
+        }
+      }
+    `),
   );
 });
 

--- a/test/graphql.test.js
+++ b/test/graphql.test.js
@@ -270,6 +270,7 @@ const assetFields = /* GraphQL */ `
     newFluidWH: gatsbyImageData(width: 300, height: 300, layout: CONSTRAINED)
     newFixedSmallerThanOriginal: gatsbyImageData(width: 30, height: 30, layout: FIXED)
     newFluidWSmallerThanOriginal: gatsbyImageData(width: 30, layout: CONSTRAINED)
+    imageCDN: gatsbyImage(width: 100)
   `;
 
 const fileFields = /* GraphQL */ `alt title customData ${assetFields}`;

--- a/test/support/assertGraphQLResponseEqualToSnapshot.js
+++ b/test/support/assertGraphQLResponseEqualToSnapshot.js
@@ -2,12 +2,17 @@ const path = require('path');
 const fs = require('fs');
 const assert = require('uvu/assert');
 
-const graphqlResponsesPath = path.resolve(path.join(__dirname, '../fixtures/graphql-responses'));
+const graphqlResponsesPath = path.resolve(
+  path.join(__dirname, '../fixtures/graphql-responses'),
+);
 
 module.exports = (snapshotName, result) => {
   const snapshotPath = path.join(graphqlResponsesPath, `${snapshotName}.json`);
 
-  if (fs.existsSync(snapshotPath)) {
+  if (
+    fs.existsSync(snapshotPath) &&
+    (!process.env.UPDATE_SNAPSHOTS || process.env.UPDATE_SNAPSHOTS === `false`)
+  ) {
     assert.is(
       JSON.stringify(result, null, 2),
       fs.readFileSync(snapshotPath, 'utf-8'),
@@ -15,4 +20,4 @@ module.exports = (snapshotName, result) => {
   }
 
   fs.writeFileSync(snapshotPath, JSON.stringify(result, null, 2), 'utf-8');
-}
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2913,6 +2913,13 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.1.tgz#18845205e86ff0038517aab7a18a62a6b9f71275"
   integrity sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==
 
+"@types/sharp@^0.29.5":
+  version "0.29.5"
+  resolved "https://registry.yarnpkg.com/@types/sharp/-/sharp-0.29.5.tgz#9c7032d30d138ad16dde6326beaff2af757b91b3"
+  integrity sha512-3TC+S3H5RwnJmLYMHrcdfNjz/CaApKmujjY9b6PU/pE6n0qfooi99YqXGWoW8frU9EWYj/XTI35Pzxa+ThAZ5Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/tmp@^0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
@@ -4102,7 +4109,7 @@ cacheable-request@^6.0.0:
     normalize-url "^4.1.0"
     responselike "^1.0.2"
 
-cacheable-request@^7.0.1:
+cacheable-request@^7.0.1, cacheable-request@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.2.tgz#ea0d0b889364a25854757301ca12b2da77f91d27"
   integrity sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==
@@ -4494,6 +4501,14 @@ color-string@^1.6.0:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
+color-string@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.0.tgz#63b6ebd1bec11999d1df3a79a7569451ac2be8aa"
+  integrity sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/color/-/color-4.0.1.tgz#21df44cd10245a91b1ccf5ba031609b0e10e7d67"
@@ -4501,6 +4516,14 @@ color@^4.0.1:
   dependencies:
     color-convert "^2.0.1"
     color-string "^1.6.0"
+
+color@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-4.2.1.tgz#498aee5fce7fc982606c8875cab080ac0547c884"
+  integrity sha512-MFJr0uY4RvTQUKvPq7dh9grVOTYSFeXja2mBXioCGjnjJoXrAp9jJ1NQTDR73c9nwBSAQiNKloKl5zq9WB9UPw==
+  dependencies:
+    color-convert "^2.0.1"
+    color-string "^1.9.0"
 
 colord@^2.0.1, colord@^2.6:
   version "2.7.0"
@@ -5374,6 +5397,11 @@ detect-libc@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
+
+detect-libc@^2.0.0, detect-libc@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.1.tgz#e1897aa88fa6ad197862937fbc0441ef352ee0cd"
+  integrity sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==
 
 detect-newline@^1.0.3:
   version "1.0.3"
@@ -6885,6 +6913,27 @@ gatsby-core-utils@^3.1.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^3.10.0-next.3:
+  version "3.10.0-next.3"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-3.10.0-next.3.tgz#284b59b93543d71256afdfaaa4c47c982419d554"
+  integrity sha512-2bKijDz2c7Eigd8rB5/5l7n8psWvPjggVBK1TtrjciRR8a9BQbz+nHBHgr+GsC5ZBEjp1J6VKFOKO4EAmCUx+w==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fastq "^1.13.0"
+    file-type "^16.5.3"
+    fs-extra "^10.0.0"
+    got "^11.8.3"
+    import-from "^4.0.0"
+    lmdb "^2.2.4"
+    lock "^1.1.0"
+    node-object-hash "^2.3.10"
+    proper-lockfile "^4.1.2"
+    resolve-from "^5.0.0"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-graphiql-explorer@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-2.0.0.tgz#939e10f2dd38add625a32f4888407090938798a8"
@@ -7004,6 +7053,19 @@ gatsby-plugin-utils@^2.0.0:
     "@babel/runtime" "^7.15.4"
     joi "^17.4.2"
 
+gatsby-plugin-utils@^3.4.0-next.3:
+  version "3.4.0-next.3"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-3.4.0-next.3.tgz#4fe80e308db7dcc489512a35ede2730a1f55dadc"
+  integrity sha512-iq5wGIfCI/IlAZiFh2Novj+Zjh47Mo/Zms+G6zQ0X5aBMoanaMq6VBRRDcSriOvvnb8equYbXpDB9izK4g8GSQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    gatsby-core-utils "^3.10.0-next.3"
+    gatsby-sharp "^0.4.0-next.2"
+    graphql-compose "^9.0.7"
+    import-from "^4.0.0"
+    joi "^17.4.2"
+    mime "^3.0.0"
+
 gatsby-react-router-scroll@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-5.0.0.tgz#a53707bff2a442f9dc3245c2da19091956f04eaf"
@@ -7075,6 +7137,14 @@ gatsby-recipes@^1.0.0:
     ws "^7.3.0"
     xstate "^4.9.1"
     yoga-layout-prebuilt "^1.9.6"
+
+gatsby-sharp@^0.4.0-next.2:
+  version "0.4.0-next.2"
+  resolved "https://registry.yarnpkg.com/gatsby-sharp/-/gatsby-sharp-0.4.0-next.2.tgz#d448a20897ca9702adc248ff79c4347fb57fb8d1"
+  integrity sha512-crTj4QAmsFPmcsMC/nmsih6l0ppAvK9gTT/2/Hjlna7SnsgOmMt7jUUx0DVuowghkTc0eurzkxEPNnOWPbvTNw==
+  dependencies:
+    "@types/sharp" "^0.29.5"
+    sharp "^0.30.1"
 
 gatsby-telemetry@^3.0.0:
   version "3.0.0"
@@ -7590,6 +7660,23 @@ got@^11.8.2:
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
 
+got@^11.8.3:
+  version "11.8.3"
+  resolved "https://registry.yarnpkg.com/got/-/got-11.8.3.tgz#f496c8fdda5d729a90b4905d2b07dbd148170770"
+  integrity sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==
+  dependencies:
+    "@sindresorhus/is" "^4.0.0"
+    "@szmarczak/http-timer" "^4.0.5"
+    "@types/cacheable-request" "^6.0.1"
+    "@types/responselike" "^1.0.0"
+    cacheable-lookup "^5.0.3"
+    cacheable-request "^7.0.2"
+    decompress-response "^6.0.0"
+    http2-wrapper "^1.0.0-beta.5.2"
+    lowercase-keys "^2.0.0"
+    p-cancelable "^2.0.0"
+    responselike "^2.0.0"
+
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -7616,6 +7703,13 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
+
+graphql-compose@^9.0.7:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/graphql-compose/-/graphql-compose-9.0.7.tgz#f9a2161d89691506466258ef54f279cbdd7ffeec"
+  integrity sha512-1EreO/vtdF/vaXYtPGW/RIlJbAAe8bWJ0mlvIa3s4YytsydbqiIFv80QUNlD9Bdl9iezLze70a6quC+3BAMzjw==
+  dependencies:
+    graphql-type-json "0.3.2"
 
 graphql-compose@~7.25.0, graphql-compose@~7.25.1:
   version "7.25.1"
@@ -8137,6 +8231,11 @@ import-from@3.0.0:
   integrity sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==
   dependencies:
     resolve-from "^5.0.0"
+
+import-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/import-from/-/import-from-4.0.0.tgz#2710b8d66817d232e16f4166e319248d3d5492e2"
+  integrity sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ==
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -9183,6 +9282,17 @@ lmdb-store@^1.6.8:
   optionalDependencies:
     msgpackr "^1.4.7"
 
+lmdb@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/lmdb/-/lmdb-2.2.4.tgz#6494d5a1d1db152e0be759edcfa06893e4cbdb53"
+  integrity sha512-gto+BB2uEob8qRiTlOq+R3uX0YNHsX9mjxj9Sbdue/LIKqu6IlZjrsjKeGyOMquc/474GEqFyX2pdytpydp0rQ==
+  dependencies:
+    msgpackr "^1.5.4"
+    nan "^2.14.2"
+    node-gyp-build "^4.2.3"
+    ordered-binary "^1.2.4"
+    weak-lru-cache "^1.2.2"
+
 load-bmfont@^1.3.1, load-bmfont@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.1.tgz#c0f5f4711a1e2ccff725a7b6078087ccfcddd3e9"
@@ -9250,7 +9360,7 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lock@^1.0.0:
+lock@^1.0.0, lock@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/lock/-/lock-1.1.0.tgz#53157499d1653b136ca66451071fca615703fa55"
   integrity sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU=
@@ -9997,6 +10107,11 @@ mime@^2.4.0, mime@^2.4.4, mime@^2.5.2:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.5.2.tgz#6e3dc6cc2b9510643830e5f19d5cb753da5eeabe"
   integrity sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==
 
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-3.0.0.tgz#b374550dca3a0c18443b0c950a6a58f1931cf7a7"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
+
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -10177,6 +10292,13 @@ msgpackr@^1.4.7:
   optionalDependencies:
     msgpackr-extract "^1.0.14"
 
+msgpackr@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/msgpackr/-/msgpackr-1.5.4.tgz#2b6ea6cb7d79c0ad98fc76c68163c48eda50cf0d"
+  integrity sha512-Z7w5Jg+2Q9z9gJxeM68d7tSuWZZGnFIRhZnyqcZCa/1dKkhOCNvR1TUV3zzJ3+vj78vlwKRzUgVDlW4jiSOeDA==
+  optionalDependencies:
+    msgpackr-extract "^1.0.14"
+
 multer@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/multer/-/multer-1.4.3.tgz#4db352d6992e028ac0eacf7be45c6efd0264297b"
@@ -10327,10 +10449,22 @@ node-abi@^2.21.0:
   dependencies:
     semver "^5.4.1"
 
+node-abi@^3.3.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.8.0.tgz#679957dc8e7aa47b0a02589dbfde4f77b29ccb32"
+  integrity sha512-tzua9qWWi7iW4I42vUPKM+SfaF0vQSLAm4yO5J83mSwB7GeoWrDKC/K+8YCnYNwqP5duwazbw2X9l4m8SC2cUw==
+  dependencies:
+    semver "^7.3.5"
+
 node-addon-api@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.2.0.tgz#117cbb5a959dff0992e1c586ae0393573e4d2a87"
   integrity sha512-eazsqzwG2lskuzBqCGPi7Ac2UgOoMz8JVOXVhTvvPDYhthvNpefx8jWD8Np7Gv+2Sz0FlPWZk0nJV0z598Wn8Q==
+
+node-addon-api@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
+  integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
 node-eta@^0.9.0:
   version "0.9.0"
@@ -10354,7 +10488,7 @@ node-gyp-build@^4.2.3:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
   integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
-node-object-hash@^2.3.9:
+node-object-hash@^2.3.10, node-object-hash@^2.3.9:
   version "2.3.10"
   resolved "https://registry.yarnpkg.com/node-object-hash/-/node-object-hash-2.3.10.tgz#4b0c1a3a8239e955f0db71f8e00b38b5c0b33992"
   integrity sha512-jY5dPJzw6NHd/KPSfPKJ+IHoFS81/tJ43r34ZeNMXGzCOM8jwQDCD12HYayKIB6MuznrnqIYy2e891NA2g0ibA==
@@ -10766,6 +10900,11 @@ ordered-binary@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.1.3.tgz#11dbc0a4cb7f8248183b9845e031b443be82571e"
   integrity sha512-tDTls+KllrZKJrqRXUYJtIcWIyoQycP7cVN7kzNNnhHKF2bMKHflcAQK+pF2Eb1iVaQodHxqZQr0yv4HWLGBhQ==
+
+ordered-binary@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/ordered-binary/-/ordered-binary-1.2.4.tgz#51d3a03af078a0bdba6c7bc8f4fedd1f5d45d83e"
+  integrity sha512-A/csN0d3n+igxBPfUrjbV5GC69LWj2pjZzAAeeHXLukQ4+fytfP4T1Lg0ju7MSPSwq7KtHkGaiwO8URZN5IpLg==
 
 org-regex@^1.0.0:
   version "1.0.0"
@@ -11577,6 +11716,25 @@ prebuild-install@^6.1.4:
     pump "^3.0.0"
     rc "^1.2.7"
     simple-get "^3.0.3"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
+prebuild-install@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.0.1.tgz#c10075727c318efe72412f333e0ef625beaf3870"
+  integrity sha512-QBSab31WqkyxpnMWQxubYAHR5S9B2+r81ucocew34Fkl98FhvKIF50jIJnNOBmAZfyNV7vE5T6gd3hTVWgY6tg==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^1.0.1"
+    node-abi "^3.3.0"
+    npmlog "^4.0.1"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
     tar-fs "^2.0.0"
     tunnel-agent "^0.6.0"
 
@@ -12721,6 +12879,20 @@ sharp@^0.29.1:
     tar-fs "^2.1.1"
     tunnel-agent "^0.6.0"
 
+sharp@^0.30.1:
+  version "0.30.2"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.30.2.tgz#95b309b2740424702dc19b62a62595dd34a458b1"
+  integrity sha512-mrMeKI5ECTdYhslPlA2TbBtU3nZXMEBcQwI6qYXjPlu1LpW4HBZLFm6xshMI1HpIdEEJ3UcYp5AKifLT/fEHZQ==
+  dependencies:
+    color "^4.2.1"
+    detect-libc "^2.0.1"
+    node-addon-api "^4.3.0"
+    prebuild-install "^7.0.1"
+    semver "^7.3.5"
+    simple-get "^4.0.1"
+    tar-fs "^2.1.1"
+    tunnel-agent "^0.6.0"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -12780,6 +12952,15 @@ simple-get@^3.0.3, simple-get@^3.1.0:
   integrity sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==
   dependencies:
     decompress-response "^4.2.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
+
+simple-get@^4.0.0, simple-get@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
     once "^1.3.1"
     simple-concat "^1.0.0"
 
@@ -14371,6 +14552,11 @@ weak-lru-cache@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.1.3.tgz#8a691884501b611d2b5aeac1ee5a011b2a97d9a8"
   integrity sha512-5LDIv+sr6uzT94Hhcq7Qv7gt3jxol4iMWUqOgJSLYbB5oO7bTSMqIBtKsytm8N2BufYOdJw86/qu+SDfbo/wKQ==
+
+weak-lru-cache@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/weak-lru-cache/-/weak-lru-cache-1.2.2.tgz#fdbb6741f36bae9540d12f480ce8254060dccd19"
+  integrity sha512-DEAoo25RfSYMuTGc9vPJzZcZullwIqRDSI9LOy+fkCJPi6hykCnfKaXTuPBDuXAUcqHXyOgFtHNp/kB2FjYHbw==
 
 web-namespaces@^1.0.0:
   version "1.1.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6913,10 +6913,10 @@ gatsby-core-utils@^3.1.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
-gatsby-core-utils@^3.10.0-next.3:
-  version "3.10.0-next.3"
-  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-3.10.0-next.3.tgz#284b59b93543d71256afdfaaa4c47c982419d554"
-  integrity sha512-2bKijDz2c7Eigd8rB5/5l7n8psWvPjggVBK1TtrjciRR8a9BQbz+nHBHgr+GsC5ZBEjp1J6VKFOKO4EAmCUx+w==
+gatsby-core-utils@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-3.10.0.tgz#52be8a9a891d95686a7ee0c1cfef44f8e362232b"
+  integrity sha512-yaRI/uUsbIggPRfh0y6CH+fy2AqbFFLxCYndw5nrVByEY40+KaKs0wOF4yIgPRBZZUHOyfBJ+1AGo2JLHdY5lA==
   dependencies:
     "@babel/runtime" "^7.15.4"
     ci-info "2.0.0"
@@ -7053,14 +7053,14 @@ gatsby-plugin-utils@^2.0.0:
     "@babel/runtime" "^7.15.4"
     joi "^17.4.2"
 
-gatsby-plugin-utils@^3.4.0-next.3:
-  version "3.4.0-next.3"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-3.4.0-next.3.tgz#4fe80e308db7dcc489512a35ede2730a1f55dadc"
-  integrity sha512-iq5wGIfCI/IlAZiFh2Novj+Zjh47Mo/Zms+G6zQ0X5aBMoanaMq6VBRRDcSriOvvnb8equYbXpDB9izK4g8GSQ==
+gatsby-plugin-utils@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-3.4.0.tgz#210fc7f51247388c1bc0a966a05acda79eab27ea"
+  integrity sha512-ACMIJZ/yaGDgNfw3cIGytbrIMK88rvv/r/Art6gPgu7g664uAh4FDnVqJQyFbJ3G+3gCRKtNs4sRxEx2fJib9A==
   dependencies:
     "@babel/runtime" "^7.15.4"
-    gatsby-core-utils "^3.10.0-next.3"
-    gatsby-sharp "^0.4.0-next.2"
+    gatsby-core-utils "^3.10.0"
+    gatsby-sharp "^0.4.0"
     graphql-compose "^9.0.7"
     import-from "^4.0.0"
     joi "^17.4.2"
@@ -7138,10 +7138,10 @@ gatsby-recipes@^1.0.0:
     xstate "^4.9.1"
     yoga-layout-prebuilt "^1.9.6"
 
-gatsby-sharp@^0.4.0-next.2:
-  version "0.4.0-next.2"
-  resolved "https://registry.yarnpkg.com/gatsby-sharp/-/gatsby-sharp-0.4.0-next.2.tgz#d448a20897ca9702adc248ff79c4347fb57fb8d1"
-  integrity sha512-crTj4QAmsFPmcsMC/nmsih6l0ppAvK9gTT/2/Hjlna7SnsgOmMt7jUUx0DVuowghkTc0eurzkxEPNnOWPbvTNw==
+gatsby-sharp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/gatsby-sharp/-/gatsby-sharp-0.4.0.tgz#9e26c004935750bd334fb041da1b0ad5a5a6955c"
+  integrity sha512-Q2iP6HEs1MRdcMRj7NwZ4l6/1U61vx2DrWNgGwqEEhIFAAgUMlWscaeCpEgahC3t4D66LmuDQkbzBvBcH0Dwxw==
   dependencies:
     "@types/sharp" "^0.29.5"
     sharp "^0.30.1"


### PR DESCRIPTION
This PR:
- Adds support for the new [Gatsby Image CDN feature](https://www.gatsbyjs.com/docs/how-to/plugins-and-themes/creating-a-source-plugin/#enabling-image-cdn-support)
- Adds snapshot tests for image CDN fields
- Adds an env var for updating snapshots (`UPDATE_SNAPSHOTS`)
- Adds `/* GraphQL */` comments to test queries for GraphQL syntax highlighting and auto-formatting