### PR TITLE
Fix locales node manifest issue

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -68,7 +68,7 @@ const shouldUpgradeGatsbyVersion =
   lt(gatsbyVersion, GATSBY_VERSION_MANIFEST_V2) && !gatsbyVersionIsPrerelease;
 
 // We only want to create one manifest for all locales, in the future we'll have a more robust solution for node manifests and locales.
-const nodeManifestsIdsCreatedSet = new Set()
+const nodeManifestsIdsCreatedSet = new Set();
 
 const datocmsCreateNodeManifest = ({ node, context }) => {
   try {
@@ -97,7 +97,7 @@ const datocmsCreateNodeManifest = ({ node, context }) => {
         node,
         updatedAtUTC: updatedAt,
       });
-      nodeManifestsIdsCreatedSet.add(manifestId)
+      nodeManifestsIdsCreatedSet.add(manifestId);
     } else if (!createNodeManifestIsSupported && !warnOnceForNoSupport) {
       console.warn(
         `DatoCMS: Your version of Gatsby core doesn't support Content Sync (via the unstable_createNodeManifest action). Please upgrade to the latest version to use Content Sync in your site.`,


### PR DESCRIPTION
We were creating a node manifest for every language locale that a site has. Because we aren't distinguishing between them in our manifest Ids they end up writing overtop one another.

ie node `1234567` locale `en` will write out a manifest `1234567-timestamp` and then node `1234567` locale `de` will write out a manifest at the same location `1234567-timestamp`. This was causing some issues for some sites if they didn't link their non-primary locales properly.

We are going to do a more robust solution down the line where we write out a separate manifest for each locale but this will take more work. This PR unblocks some users that run into that issue while we come up with a better solution.