### PR TITLE
test: chdir before importing anything from gatsby so main and child processes have shared cwd

### DIFF
--- a/test/support/buildQueryExecutor.js
+++ b/test/support/buildQueryExecutor.js
@@ -1,17 +1,21 @@
 require('regenerator-runtime/runtime');
+const path = require('path');
+const gatsbyProjectPath = path.resolve(
+  path.join(__dirname, '../fixtures/sample-gatsby-structure'),
+);
+// We are setting up CWD early, before importing any of gatsby files, so that
+// `process.cwd()` in THIS process and also in child processes spawned by gatsby
+// is actually the same. Otherwise `cache` would be backed by different DBs and
+// therefore wouldn't actually allow to share data between processes.
+process.chdir(gatsbyProjectPath);
+
 const { bootstrap } = require('gatsby/dist/bootstrap');
 const reporter = require('gatsby-cli/lib/reporter');
 const { setStore } = require('gatsby-cli/lib/reporter/redux');
-const path = require('path');
 const rimraf = require('rimraf');
 
 module.exports = async function buildQueryExecutor(apiToken) {
-  const gatsbyProjectPath = path.resolve(
-    path.join(__dirname, '../fixtures/sample-gatsby-structure'),
-  );
   rimraf.sync(path.join(gatsbyProjectPath, './.cache'));
-
-  process.chdir(gatsbyProjectPath);
 
   process.env.DATOCMS_API_TOKEN = apiToken;
 


### PR DESCRIPTION
Gatsby removed conditional code paths for feature flags that were enabled by default (when running actual gatsby commands) in https://github.com/gatsbyjs/gatsby/pull/36810

This means that test setup for this plugin was actually not using PQR mode when testing against v4 and earlier and falled back to single process query running, but that changed in v5 and now there is no way not to run in PQR mode. This adjusts the test helper setup so that `process.cwd()` is the same for "main process" and PQR workers by setting it up before any of Gatsby imports (some of gatsby modules would init variables using `process.cwd()` and that includes cache that is used by this plugin to share data between processes