### PR TITLE
fix: add unpublishingScheduledAt to DatoCmsMetaField

### DIFF
--- a/src/hooks/sourceNodes/createTypes/fieldTypes/DatoCmsMetaField.js
+++ b/src/hooks/sourceNodes/createTypes/fieldTypes/DatoCmsMetaField.js
@@ -13,6 +13,7 @@ module.exports = ({ actions, schema }) => {
         updatedAt: dateType,
         publishedAt: dateType,
         firstPublishedAt: dateType,
+        unpublishingScheduledAt: dateType,
         isValid: 'Boolean',
         status: 'String',
       },


### PR DESCRIPTION
Added a missing meta field. Needed to hotfix an issue with Gatsby Cloud where unpublishing a record doesn't immediately affect the data returned by a static query (delay of a few hours observed) thus client-side filtering is required.